### PR TITLE
Add Heroku deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ This app is running on Heroku, using the free test version of the
 
 <https://node-neo4j-template.herokuapp.com/>
 
-If you want to run your own instance similarly, it's easy:
+If you want to run your own instance similarly, it's just one click of a button away:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
+If you prefer to deploy this sample app manually, these are the steps:
 
 ```
 heroku create [your-app-name]

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "node-neo4j-template",
+  "description": "A template app for using Neo4j from Node.js, using the node-neo4j driver. Deployment using GrapheneDB.",
+  "website": "https://github.com/thingdom/node-neo4j",
+  "keywords": ["node", "neo4j"],
+  "addons": ["graphenedb:chalk"]
+}


### PR DESCRIPTION
This PR adds a [Heroku deploy button](https://blog.heroku.com/archives/2014/8/7/heroku-button) as an alternative way to deploy the template app.
